### PR TITLE
[FIX-DOC] Avoid TypeError when running example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ def timeit(ctx, call):
 
 def to_requests(ctx):
     get(ctx['url'])
+    return ctx
 
 fancy_get = wrap(to_requests, middleware=[log, timeit])
 fancy_get({'url':'https://google.com'})


### PR DESCRIPTION
Without this fix, running the code sample of `fancy_get` will result with `TypeError: 'NoneType' object does not support item assignment` from `ctx['duration'] = ended`