### PR TITLE
Avoid using a mutable default value as an argument

### DIFF
--- a/formation/for_requests.py
+++ b/formation/for_requests.py
@@ -138,12 +138,14 @@ def text_response(ctx):
     return res.text, res.status_code, res.headers
 
 
-def build_sender(middleware=[], base_uri=None, default_response_as=None):
+def build_sender(middleware=None, base_uri=None, default_response_as=None):
+    middleware = middleware or []
     wrapped = wrap(requests_adapter, middleware=middleware)
 
-    def sender(method, url, session_context={}, params={}, response_as=None, **kwargs):
+    def sender(method, url, session_context=None, params=None, response_as=None, **kwargs):
+        session_context = session_context or {}
+        params = params if isinstance(params, dict) else {} if not params else params.to_dict()
         resolved_response_as = response_as or default_response_as or _raw_response
-        params = params if isinstance(params, dict) else params.to_dict()
         (url, params) = apply_params(url, params)
         req = FormationHttpRequest(
             url=urljoin(base_uri, url), method=method, params=params, **kwargs

--- a/formation/formation.py
+++ b/formation/formation.py
@@ -11,7 +11,8 @@ _REQ_PARENT_ID = "req.parent.id"
 _REQ_DURATION = "req.duration_us"
 
 
-def wrap(call, middleware=[]):
+def wrap(call, middleware=None):
+    middleware = middleware or []
     return reduce(
         lambda acc, m: lambda ctx: m(ctx, acc),
         reversed(middleware),

--- a/formation/middleware/breaker.py
+++ b/formation/middleware/breaker.py
@@ -31,8 +31,9 @@ def trigger_breaker_if(trigger):
 
 
 def circuit_breaker(
-    logger, name, fail_max=5, reset_timeout=60, state_storage=None, exclude=[]
+    logger, name, fail_max=5, reset_timeout=60, state_storage=None, exclude=None
 ):
+    exclude = exclude or []
     breaker = pybreaker.CircuitBreaker(
         name=name,
         listeners=[breaker_logger(logger)],


### PR DESCRIPTION
The purpose of this change is to avoid using a mutable default value as an argument, since it's not good to do so in python. 
This is an article that demonstrate the issue:
https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html